### PR TITLE
feat: multiple turbo streams in one response

### DIFF
--- a/src/lib/hotwire-middleware.ts
+++ b/src/lib/hotwire-middleware.ts
@@ -1,8 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 
+export enum MiddlewareWriteMode {
+  SEND,
+  WRITE
+}
+
 type TurboStreamActionResponseHandler = (
   target: string,
-  options?: StreamOptions
+  options?: StreamOptions,
+  mode?: MiddlewareWriteMode
 ) => Promise<void>;
 
 /**
@@ -131,10 +137,10 @@ export const middleware = (
 ) => {
   const streamActionHandler =
     (action: TurboStreamActions): TurboStreamActionResponseHandler =>
-    async (target: string, options?: StreamOptions) => {
-      res.setHeader('Content-Type', ['text/vnd.turbo-stream.html']);
-      res.send(await stream(res, target, action, options));
-    };
+      async (target: string, options?: StreamOptions, mode: MiddlewareWriteMode = MiddlewareWriteMode.SEND) => {
+        res.setHeader('Content-Type', ['text/vnd.turbo-stream.html']);
+        res[mode === MiddlewareWriteMode.SEND ? "send" : "write"](await stream(res, target, action, options));
+      };
 
   const turboStream: TurboStream = {
     append: streamActionHandler(TurboStreamActions.append),


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the feature to return multiple responses

- **What is the current behavior?** (You can also link to an open issue here)
Related issue https://github.com/deriegle/express-hotwire/issues/42

- **What is the new behavior (if this is a feature change)?**
Instead of using the default `res.send` the newly introduced `MiddlewareWriteMode` allows switching to `res.write` and letting the user handle response end via `res.end()`
